### PR TITLE
Prevent compilation on gnu/linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ pg_prefaulter
 .pgdata_primary/
 pg_prefaulter.toml
 dist/
+*.log

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,12 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 PG_PREFAULTER ?= pg_prefaulter
+UNAME := $(shell uname)
+
+# Can only be compiled/ran on BSD, as unix.SIGINFO is non-existent on GNU/Linux.
+ifeq ($(UNAME), Linux)
+$(error Linux is currently unsupported, exiting)
+endif
 
 default:: help
 


### PR DESCRIPTION
Linux doesn't have a concept of `SIGINFO`, so compilation/testing abruptly stops without much hint as to the error.

Previously
```
$ make check
go test -v $(go list ./... |grep -v 'vendor')
# github.com/joyent/pg_prefaulter/agent
agent/agent.go:117:83: undefined: unix.SIGINFO
agent/agent.go:246:9: undefined: unix.SIGINFO
# github.com/joyent/pg_prefaulter/agent
agent/agent.go:117:83: undefined: unix.SIGINFO
agent/agent.go:246:9: undefined: unix.SIGINFO
make: *** [GNUmakefile:22: check] Error 2
```

Currently:
```
$ make check 
GNUmakefile:8: *** Linux is currently unsupported, exiting.  Stop.
```

With the addition of the top-level `ifeq` check in the Makefile, a user who wishes to compile `pg_prefaulter` on an incomplete OS, gets a helpful error message. 

Also adds `*.log` to the `.gitignore` file, so as to ignore the logfiles generated from the `*db` makefile targets. 