### PR TITLE
Decouple the initialization of the connection pool with the main event loop

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -130,6 +130,18 @@ func init() {
 
 	{
 		const (
+			key          = config.KeyRetryDBInit
+			longName     = "retry-init"
+			defaultValue = false
+			description  = `Retry connecting to the database during initialization`
+		)
+		runCmd.Flags().Bool(longName, defaultValue, description)
+		viper.BindPFlag(key, runCmd.Flags().Lookup(longName))
+		viper.SetDefault(key, defaultValue)
+	}
+
+	{
+		const (
 			key          = config.KeyWALReadAhead
 			longName     = "wal-readahead"
 			shortName    = "n"

--- a/config/config.go
+++ b/config/config.go
@@ -37,9 +37,14 @@ type Config struct {
 	DBPool
 	*Metrics
 
+	Agent
 	FHCacheConfig
 	IOCacheConfig
 	WALCacheConfig
+}
+
+type Agent struct {
+	RetryInit bool
 }
 
 type FHCacheConfig struct {
@@ -124,6 +129,11 @@ func NewDefault() (*Config, error) {
 		pgxLogLevel = pgx.LogLevelDebug
 	default:
 		panic(fmt.Sprintf("unsupported log level: %q", logLevel))
+	}
+
+	agentConfig := Agent{}
+	{
+		agentConfig.RetryInit = viper.GetBool(KeyRetryDBInit)
 	}
 
 	fhConfig := FHCacheConfig{}
@@ -230,6 +240,7 @@ func NewDefault() (*Config, error) {
 		},
 		Metrics: cmc,
 
+		Agent:          agentConfig,
 		FHCacheConfig:  fhConfig,
 		IOCacheConfig:  ioConfig,
 		WALCacheConfig: walConfig,

--- a/config/consts.go
+++ b/config/consts.go
@@ -23,6 +23,7 @@ const (
 	KeyLogLevel = "log.level"
 
 	KeyNumIOThreads = "run.num-io-threads"
+	KeyRetryDBInit  = "run.retry-db-init"
 
 	KeyPGData         = "postgresql.pgdata"
 	KeyPGDatabase     = "postgresql.database"

--- a/init/pg_prefaulter.smf
+++ b/init/pg_prefaulter.smf
@@ -14,7 +14,7 @@
     </dependency>
 
     <method_context/>
-    <exec_method name='start' type='method' exec='/opt/local/bin/pg_prefaulter run --config=%{config_file}' timeout_seconds='60'>
+    <exec_method name='start' type='method' exec='/opt/local/bin/pg_prefaulter run --config=%{config_file} --retry-db-init' timeout_seconds='60'>
       <method_context>
         <method_environment>
           <envvar name='HOME' value='/var/tmp'/>

--- a/pg_prefaulter.toml.sample-all
+++ b/pg_prefaulter.toml.sample-all
@@ -20,6 +20,7 @@
 
 [run]
 num-io-threads = 1500
+retry-db-init = false
 
 [circonus]
 #debug = false


### PR DESCRIPTION
If PostgreSQL is not available for new connections when `pg_preaulter` first starts up, retry in the event loop.  The DB connection pool now gates all DB query activity.  Notably this is required to prevent [SMF(5)](https://www.illumos.org/man/5/smf) from marking `pg_prefaulter` as failed and moving the service into the `maintenance` state when it takes an extended period of time for PostgreSQL to startup and complete its recovery.  Process and service managers that loop indefinitely will no longer be aware that `pg_prefaulter` is unable to connect to the database.  This fix is partial in that it depends on #17 being resolved (for tomorrow).

Fixes: #18