### PR TITLE
Use the PurgeVisitorFunc to close all file descriptors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,10 +8,11 @@
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
-  branch = "master"
+  branch = "gh-37"
   name = "github.com/bluele/gcache"
   packages = ["."]
-  revision = "6748215c018ea9d23fd269d499a3553c94d3ddf9"
+  revision = "cd4b07ab8dfbdc5307407e21ecae479a1a1c8412"
+  source = "https://github.com/sean-/gcache.git"
 
 [[projects]]
   name = "github.com/circonus-labs/circonus-gometrics"
@@ -172,6 +173,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ea0237d6833aeec87d71817bc558725f6958613fff2fb83e6bf3e5108f479ae"
+  inputs-digest = "0a25b879ee38e4c495c394497e05129c2f4adde4b9b8127ef3ec28f1f7b80816"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,9 +25,10 @@
   branch = "master"
   name = "github.com/alecthomas/units"
 
-[[constraint]]
-  branch = "master"
+[[override]]
   name = "github.com/bluele/gcache"
+  source = "https://github.com/sean-/gcache.git"
+  branch = "gh-37"
 
 [[constraint]]
   branch = "master"

--- a/agent/fhcache/cache.go
+++ b/agent/fhcache/cache.go
@@ -69,17 +69,17 @@ func New(ctx context.Context, cfg *config.Config, metrics *cgm.CirconusMetrics) 
 			if !ok {
 				log.Panic().Msgf("bad, evicting something not a file handle: %+v", fhCacheValue)
 			}
+			defer fhCacheValue.close()
 
-			fhCacheValue.close()
 			fhc.metrics.Increment(config.MetricsSysCloseCount)
 		}).
 		PurgeVisitorFunc(func(fhCacheKeyRaw, fhCacheValueRaw interface{}) {
 			fhCacheValue, ok := fhCacheValueRaw.(*_Value)
 			if !ok {
-				log.Panic().Msgf("bad, evicting something not a file handle: %+v", fhCacheValue)
+				log.Panic().Msgf("bad, purging something not a file handle: %+v", fhCacheValue)
 			}
+			defer fhCacheValue.close()
 
-			fhCacheValue.close()
 			fhc.metrics.Increment(config.MetricsSysCloseCount)
 		}).
 		Build()

--- a/agent/fhcache/cache.go
+++ b/agent/fhcache/cache.go
@@ -73,6 +73,15 @@ func New(ctx context.Context, cfg *config.Config, metrics *cgm.CirconusMetrics) 
 			fhCacheValue.close()
 			fhc.metrics.Increment(config.MetricsSysCloseCount)
 		}).
+		PurgeVisitorFunc(func(fhCacheKeyRaw, fhCacheValueRaw interface{}) {
+			fhCacheValue, ok := fhCacheValueRaw.(*_Value)
+			if !ok {
+				log.Panic().Msgf("bad, evicting something not a file handle: %+v", fhCacheValue)
+			}
+
+			fhCacheValue.close()
+			fhc.metrics.Increment(config.MetricsSysCloseCount)
+		}).
 		Build()
 
 	go lib.LogCacheStats(fhc.ctx, fhc.c, "filehandle-stats")

--- a/vendor/github.com/bluele/gcache/arc.go
+++ b/vendor/github.com/bluele/gcache/arc.go
@@ -335,6 +335,12 @@ func (c *ARC) Purge() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if c.purgeVisitorFunc != nil {
+		for _, item := range c.items {
+			c.purgeVisitorFunc(item.key, item.value)
+		}
+	}
+
 	c.init()
 }
 

--- a/vendor/github.com/bluele/gcache/arc_test.go
+++ b/vendor/github.com/bluele/gcache/arc_test.go
@@ -68,7 +68,7 @@ func TestARCLength(t *testing.T) {
 
 func TestARCEvictItem(t *testing.T) {
 	cacheSize := 10
-	numbers := 11
+	numbers := cacheSize + 1
 	gc := buildLoadingARCache(cacheSize)
 
 	for i := 0; i < numbers; i++ {
@@ -76,6 +76,31 @@ func TestARCEvictItem(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
+	}
+}
+
+func TestARCPurgeCache(t *testing.T) {
+	cacheSize := 10
+	purgeCount := 0
+	gc := New(cacheSize).
+		ARC().
+		LoaderFunc(loader).
+		PurgeVisitorFunc(func(k, v interface{}) {
+			purgeCount++
+		}).
+		Build()
+
+	for i := 0; i < cacheSize; i++ {
+		_, err := gc.Get(fmt.Sprintf("Key-%d", i))
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+
+	gc.Purge()
+
+	if purgeCount != cacheSize {
+		t.Errorf("failed to purge everything")
 	}
 }
 

--- a/vendor/github.com/bluele/gcache/lru.go
+++ b/vendor/github.com/bluele/gcache/lru.go
@@ -254,6 +254,14 @@ func (c *LRUCache) Purge() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if c.purgeVisitorFunc != nil {
+		for key, item := range c.items {
+			it := item.Value.(*lruItem)
+			v := it.value
+			c.purgeVisitorFunc(key, v)
+		}
+	}
+
 	c.init()
 }
 

--- a/vendor/github.com/bluele/gcache/simple.go
+++ b/vendor/github.com/bluele/gcache/simple.go
@@ -241,6 +241,12 @@ func (c *SimpleCache) Purge() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if c.purgeVisitorFunc != nil {
+		for key, item := range c.items {
+			c.purgeVisitorFunc(key, item.value)
+		}
+	}
+
 	c.init()
 }
 


### PR DESCRIPTION
Later this week I will add an invariant to ensure that the open and close count match in all cases at runtime.

This actually fixes #13