### PR TITLE
Add an invariant re: the number of open/closed file descriptors.

### DIFF
--- a/agent/fhcache/value.go
+++ b/agent/fhcache/value.go
@@ -16,6 +16,7 @@ package fhcache
 import (
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 )
@@ -37,6 +38,7 @@ func (fh *_Value) close() {
 	fh.lock.Lock()
 	defer fh.lock.Unlock()
 
+	atomic.AddUint64(&closeFDCount, 1)
 	fh.f.Close()
 	fh.f = nil
 }
@@ -47,6 +49,7 @@ func (value *_Value) open(pgdataPath string) (*os.File, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to open relation segment %q", filename)
 	}
+	atomic.AddUint64(&openFDCount, 1)
 
 	return f, nil
 }

--- a/agent/fhcache/value.go
+++ b/agent/fhcache/value.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 // _Value is the FileHandleCache value.  _Value provides synchronization around
@@ -38,9 +39,11 @@ func (fh *_Value) close() {
 	fh.lock.Lock()
 	defer fh.lock.Unlock()
 
-	atomic.AddUint64(&closeFDCount, 1)
-	fh.f.Close()
+	if err := fh.f.Close(); err != nil {
+		log.Error().Err(err).Msg("unable to close FD")
+	}
 	fh.f = nil
+	atomic.AddUint64(&closeFDCount, 1)
 }
 
 func (value *_Value) open(pgdataPath string) (*os.File, error) {


### PR DESCRIPTION
If after purge the number of open vs closed files is not the same,
panic.  The purge handler was observed to be firing with the following
patch:

```go
diff --git a/agent/agent.go b/agent/agent.go
index 9bfd1f2..0284198 100644
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -198,6 +198,7 @@ RETRY:
                // 2) Dump cache. Calling Purge() on the WALCache purges all downstream
                //    caches (i.e. ioCache and fhCache).
                if purgeCache {
+                       log.Debug().Msg("purging cache")
                        a.walCache.Purge()
                        purgeCache = false
                }
```