### PR TITLE
Human logs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -86,6 +86,12 @@
   version = "v1.7.3"
 
 [[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
+
+[[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
@@ -166,6 +172,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "36484737d8a26b665ea68ea0abd06718daee0367127383d3e6a963218bc2995e"
+  inputs-digest = "bd88d991aa9b28ab872737979cfa87abec3767e4ec8964f27f8cb93f69931847"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,3 +64,7 @@
 [[constraint]]
   name = "github.com/circonus-labs/circonus-gometrics"
   version = "1.0.0"
+
+[[constraint]]
+  name = "github.com/mattn/go-isatty"
+  version = "0.0.3"

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,9 @@ type Config struct {
 
 type Agent struct {
 	PostgreSQLPIDPath string
+	JSONLogging       bool
 	RetryInit         bool
+	UseColors         bool
 }
 
 type FHCacheConfig struct {
@@ -138,6 +140,8 @@ func NewDefault() (*Config, error) {
 	{
 		const postmasterPIDFilename = "postmaster.pid"
 		agentConfig.PostgreSQLPIDPath = path.Join(viper.GetString(KeyPGData), postmasterPIDFilename)
+		agentConfig.UseColors = viper.GetBool(KeyAgentUseColor)
+		agentConfig.JSONLogging = viper.GetBool(KeyAgentJSONLogging)
 		agentConfig.RetryInit = viper.GetBool(KeyRetryDBInit)
 	}
 

--- a/config/consts.go
+++ b/config/consts.go
@@ -22,8 +22,10 @@ const (
 
 	KeyLogLevel = "log.level"
 
-	KeyNumIOThreads = "run.num-io-threads"
-	KeyRetryDBInit  = "run.retry-db-init"
+	KeyAgentJSONLogging = "run.json-logs"
+	KeyNumIOThreads     = "run.num-io-threads"
+	KeyRetryDBInit      = "run.retry-db-init"
+	KeyAgentUseColor    = "run.use-color"
 
 	KeyPGData         = "postgresql.pgdata"
 	KeyPGDatabase     = "postgresql.database"
@@ -60,4 +62,10 @@ const (
 	MetricsXLogDumpLinesMatched  = "wal-xlogdump-lines-matched"
 	MetricsXLogDumpLinesScanned  = "wal-xlogdump-lines-scanned"
 	MetricsXLogPrefaulted        = "wal-xlog-prefaulted-count"
+)
+
+const (
+	// Use a log format that resembles time.RFC3339Nano but includes all trailing
+	// zeros so that we get fixed-width logging.
+	LogFormat = "2006-01-02T15:04:05.000000000Z07:00"
 )

--- a/pg_prefaulter.defaults.toml
+++ b/pg_prefaulter.defaults.toml
@@ -19,8 +19,16 @@
 #pg_xlogdump-path = "/usr/local/bin/pg_xlogdump"
 
 [run]
-num-io-threads = 1500
-retry-db-init = false
+# json-logs changes its default depending on whether or not stdout is a TTY.  If
+# stdout is a TTY the default changes to false.
+#json-logs = true
+#
+#num-io-threads = 1500
+#retry-db-init = false
+#
+# use-color changes its default depending on whether or not stdout is a TTY.
+# If stdout is a TTY the default changes to true.
+#use-color = false
 
 [circonus]
 #debug = false

--- a/vendor/github.com/mattn/go-isatty/.travis.yml
+++ b/vendor/github.com/mattn/go-isatty/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+  - tip
+
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+script:
+  - $HOME/gopath/bin/goveralls -repotoken 3gHdORO5k5ziZcWMBxnd9LrMZaJs8m9x5

--- a/vendor/github.com/mattn/go-isatty/LICENSE
+++ b/vendor/github.com/mattn/go-isatty/LICENSE
@@ -1,0 +1,9 @@
+Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
+
+MIT License (Expat)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/mattn/go-isatty/README.md
+++ b/vendor/github.com/mattn/go-isatty/README.md
@@ -1,0 +1,50 @@
+# go-isatty
+
+[![Godoc Reference](https://godoc.org/github.com/mattn/go-isatty?status.svg)](http://godoc.org/github.com/mattn/go-isatty)
+[![Build Status](https://travis-ci.org/mattn/go-isatty.svg?branch=master)](https://travis-ci.org/mattn/go-isatty)
+[![Coverage Status](https://coveralls.io/repos/github/mattn/go-isatty/badge.svg?branch=master)](https://coveralls.io/github/mattn/go-isatty?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/mattn/go-isatty)](https://goreportcard.com/report/mattn/go-isatty)
+
+isatty for golang
+
+## Usage
+
+```go
+package main
+
+import (
+	"fmt"
+	"github.com/mattn/go-isatty"
+	"os"
+)
+
+func main() {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Terminal")
+	} else if isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Cygwin/MSYS2 Terminal")
+	} else {
+		fmt.Println("Is Not Terminal")
+	}
+}
+```
+
+## Installation
+
+```
+$ go get github.com/mattn/go-isatty
+```
+
+## License
+
+MIT
+
+## Author
+
+Yasuhiro Matsumoto (a.k.a mattn)
+
+## Thanks
+
+* k-takata: base idea for IsCygwinTerminal
+
+    https://github.com/k-takata/go-iscygpty

--- a/vendor/github.com/mattn/go-isatty/doc.go
+++ b/vendor/github.com/mattn/go-isatty/doc.go
@@ -1,0 +1,2 @@
+// Package isatty implements interface to isatty
+package isatty

--- a/vendor/github.com/mattn/go-isatty/example_test.go
+++ b/vendor/github.com/mattn/go-isatty/example_test.go
@@ -1,0 +1,18 @@
+package isatty_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mattn/go-isatty"
+)
+
+func Example() {
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Terminal")
+	} else if isatty.IsCygwinTerminal(os.Stdout.Fd()) {
+		fmt.Println("Is Cygwin/MSYS2 Terminal")
+	} else {
+		fmt.Println("Is Not Terminal")
+	}
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_appengine.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_appengine.go
@@ -1,0 +1,15 @@
+// +build appengine
+
+package isatty
+
+// IsTerminal returns true if the file descriptor is terminal which
+// is always false on on appengine classic which is a sandboxed PaaS.
+func IsTerminal(fd uintptr) bool {
+	return false
+}
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal. This is also always false on this environment.
+func IsCygwinTerminal(fd uintptr) bool {
+	return false
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_bsd.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_bsd.go
@@ -1,0 +1,18 @@
+// +build darwin freebsd openbsd netbsd dragonfly
+// +build !appengine
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TIOCGETA
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_linux.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_linux.go
@@ -1,0 +1,18 @@
+// +build linux
+// +build !appengine,!ppc64,!ppc64le
+
+package isatty
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_linux_ppc64x.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_linux_ppc64x.go
@@ -1,0 +1,19 @@
+// +build linux
+// +build ppc64 ppc64le
+
+package isatty
+
+import (
+	"unsafe"
+
+	syscall "golang.org/x/sys/unix"
+)
+
+const ioctlReadTermios = syscall.TCGETS
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_others.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_others.go
@@ -1,0 +1,10 @@
+// +build !windows
+// +build !appengine
+
+package isatty
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal. This is also always false on this environment.
+func IsCygwinTerminal(fd uintptr) bool {
+	return false
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_others_test.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_others_test.go
@@ -1,0 +1,19 @@
+// +build !windows
+
+package isatty
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTerminal(t *testing.T) {
+	// test for non-panic
+	IsTerminal(os.Stdout.Fd())
+}
+
+func TestCygwinPipeName(t *testing.T) {
+	if IsCygwinTerminal(os.Stdout.Fd()) {
+		t.Fatal("should be false always")
+	}
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_solaris.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_solaris.go
@@ -1,0 +1,16 @@
+// +build solaris
+// +build !appengine
+
+package isatty
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+func IsTerminal(fd uintptr) bool {
+	var termio unix.Termio
+	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)
+	return err == nil
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_windows.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_windows.go
@@ -1,0 +1,94 @@
+// +build windows
+// +build !appengine
+
+package isatty
+
+import (
+	"strings"
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+const (
+	fileNameInfo uintptr = 2
+	fileTypePipe         = 3
+)
+
+var (
+	kernel32                         = syscall.NewLazyDLL("kernel32.dll")
+	procGetConsoleMode               = kernel32.NewProc("GetConsoleMode")
+	procGetFileInformationByHandleEx = kernel32.NewProc("GetFileInformationByHandleEx")
+	procGetFileType                  = kernel32.NewProc("GetFileType")
+)
+
+func init() {
+	// Check if GetFileInformationByHandleEx is available.
+	if procGetFileInformationByHandleEx.Find() != nil {
+		procGetFileInformationByHandleEx = nil
+	}
+}
+
+// IsTerminal return true if the file descriptor is terminal.
+func IsTerminal(fd uintptr) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, fd, uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}
+
+// Check pipe name is used for cygwin/msys2 pty.
+// Cygwin/MSYS2 PTY has a name like:
+//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
+func isCygwinPipeName(name string) bool {
+	token := strings.Split(name, "-")
+	if len(token) < 5 {
+		return false
+	}
+
+	if token[0] != `\msys` && token[0] != `\cygwin` {
+		return false
+	}
+
+	if token[1] == "" {
+		return false
+	}
+
+	if !strings.HasPrefix(token[2], "pty") {
+		return false
+	}
+
+	if token[3] != `from` && token[3] != `to` {
+		return false
+	}
+
+	if token[4] != "master" {
+		return false
+	}
+
+	return true
+}
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal.
+func IsCygwinTerminal(fd uintptr) bool {
+	if procGetFileInformationByHandleEx == nil {
+		return false
+	}
+
+	// Cygwin/msys's pty is a pipe.
+	ft, _, e := syscall.Syscall(procGetFileType.Addr(), 1, fd, 0, 0)
+	if ft != fileTypePipe || e != 0 {
+		return false
+	}
+
+	var buf [2 + syscall.MAX_PATH]uint16
+	r, _, e := syscall.Syscall6(procGetFileInformationByHandleEx.Addr(),
+		4, fd, fileNameInfo, uintptr(unsafe.Pointer(&buf)),
+		uintptr(len(buf)*2), 0, 0)
+	if r == 0 || e != 0 {
+		return false
+	}
+
+	l := *(*uint32)(unsafe.Pointer(&buf))
+	return isCygwinPipeName(string(utf16.Decode(buf[2 : 2+l/2])))
+}

--- a/vendor/github.com/mattn/go-isatty/isatty_windows_test.go
+++ b/vendor/github.com/mattn/go-isatty/isatty_windows_test.go
@@ -1,0 +1,35 @@
+// +build windows
+
+package isatty
+
+import (
+	"testing"
+)
+
+func TestCygwinPipeName(t *testing.T) {
+	tests := []struct {
+		name   string
+		result bool
+	}{
+		{``, false},
+		{`\msys-`, false},
+		{`\cygwin-----`, false},
+		{`\msys-x-PTY5-pty1-from-master`, false},
+		{`\cygwin-x-PTY5-from-master`, false},
+		{`\cygwin-x-pty2-from-toaster`, false},
+		{`\cygwin--pty2-from-master`, false},
+		{`\\cygwin-x-pty2-from-master`, false},
+		{`\cygwin-x-pty2-from-master-`, true}, // for the feature
+		{`\cygwin-e022582115c10879-pty4-from-master`, true},
+		{`\msys-e022582115c10879-pty4-to-master`, true},
+		{`\cygwin-e022582115c10879-pty4-to-master`, true},
+	}
+
+	for _, test := range tests {
+		want := test.result
+		got := isCygwinPipeName(test.name)
+		if want != got {
+			t.Fatalf("isatty(%q): got %v, want %v:", test.name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Use the human-friendly zerolog.ConsoleWriter when stdout is a TTY.

This change:

a) moves logging from stderr to stdout (I'm not sure why I used
   stderr to begin with)
b) uses a sane time format that abates my hostile OCD operational
   tendencies
c) Uses a human-friendly logger when stdout is a TTY.  This can be
   changed with the flag `--json-logs=(true|false)` or config value
   `run.json-logs=(true|false)`.
d) Uses colorized output when stdout is a TTY.  This can be changed
   with the flag `--use-colors=(true|false)` or the config value
   `run.use-colors=(true|false)`.

Human friendly output:
```
$ pg_prefaulter run
2017-10-06T06:42:43.690004116-07:00 |DEBU| <nil> config-file=./pg_prefaulter-follower.toml
2017-10-06T06:42:43.690153216-07:00 |DEBU| args: []
2017-10-06T06:42:43.690236783-07:00 |DEBU| starting gops(1) agent
2017-10-06T06:42:43.690332132-07:00 |DEBU| flags postgresql.host=/tmp postgresql.pgdata=/Users/seanc/go/src/github.com/joyent/pg_prefaulter/.pgdata_follower/ postgresql.poll-interval=1000 postgresql.port=5433 postgresql.user=postgres postgresql.xlog.mode=pg postgresql.xlog.pg_xlogdump-path=/opt/local/lib/postgresql96/bin/pg_xlogdump
2017-10-06T06:42:43.690803979-07:00 |INFO| Starting pg_prefaulter pid=16043
2017-10-06T06:42:43.692740595-07:00 |DEBU| filehandle cache initialized filehandle-cache-size=2000 filehandle-cache-ttl=300000 rlimit-nofile=7168
2017-10-06T06:42:43.710555175-07:00 |INFO| started IO worker threads io-worker-threads=3600
2017-10-06T06:42:43.710984084-07:00 |INFO| started WAL worker threads wal-worker-threads=4
2017-10-06T06:42:43.711073646-07:00 |DEBU| Starting wait
2017-10-06T06:42:43.711116352-07:00 |INFO| Starting pg_prefaulter agent commit=none date=unknown tag= version=dev
2017-10-06T06:42:43.716317523-07:00 |ERRO| unable to find WAL files error="FATAL: password authentication failed for user \"postgres\" (SQLSTATE 28P01): (retriable: false, purge cache: false" next step=exiting
2017-10-06T06:42:43.716813454-07:00 |DEBU| Shutting down
2017-10-06T06:42:43.720427315-07:00 |DEBU| Stopped pg_prefaulter agent
2017-10-06T06:42:43.720476034-07:00 |INFO| Stopped pg_prefaulter pid=16043
```

Structured logging:
```
$ pg_prefaulter run | cat
{"time":"2017-10-06T06:43:34.827738183-07:00","level":"debug","config-file":"./pg_prefaulter-follower.toml"}
{"time":"2017-10-06T06:43:34.827828887-07:00","level":"debug","message":"args: []"}
{"time":"2017-10-06T06:43:34.827960705-07:00","level":"debug","message":"starting gops(1) agent"}
{"time":"2017-10-06T06:43:34.828050108-07:00","level":"debug","postgresql.pgdata":"/Users/seanc/go/src/github.com/joyent/pg_prefaulter/.pgdata_follower/","postgresql.host":"/tmp","postgresql.port":5433,"postgresql.user":"postgres","postgresql.xlog.mode":"pg","postgresql.xlog.pg_xlogdump-path":"/opt/local/lib/postgresql96/bin/pg_xlogdump","postgresql.poll-interval":1000,"message":"flags"}
{"time":"2017-10-06T06:43:34.828510862-07:00","level":"info","pid":16113,"message":"Starting pg_prefaulter"}
{"time":"2017-10-06T06:43:34.830408069-07:00","level":"debug","rlimit-nofile":7168,"filehandle-cache-size":2000,"filehandle-cache-ttl":300000,"message":"filehandle cache initialized"}
{"time":"2017-10-06T06:43:34.847611151-07:00","level":"info","io-worker-threads":3600,"message":"started IO worker threads"}
{"time":"2017-10-06T06:43:34.848289272-07:00","level":"info","wal-worker-threads":4,"message":"started WAL worker threads"}
{"time":"2017-10-06T06:43:34.848319666-07:00","level":"debug","message":"Starting wait"}
{"time":"2017-10-06T06:43:34.848328614-07:00","level":"info","date":"unknown","version":"dev","commit":"none","tag":"","message":"Starting pg_prefaulter agent"}
{"time":"2017-10-06T06:43:34.853523595-07:00","level":"error","error":"FATAL: password authentication failed for user \"postgres\" (SQLSTATE 28P01): (retriable: false, purge cache: false","next step":"exiting","message":"unable to find WAL files"}
{"time":"2017-10-06T06:43:34.854155468-07:00","level":"debug","message":"Shutting down"}
{"time":"2017-10-06T06:43:34.857423618-07:00","level":"debug","message":"Stopped pg_prefaulter agent"}
{"time":"2017-10-06T06:43:34.857437766-07:00","level":"info","pid":16113,"message":"Stopped pg_prefaulter"}
```

Fixes: #10