### PR TITLE
Terminate pg_xlogdump once an iteration

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -154,8 +154,8 @@ func (a *Agent) Start() {
 	// the following six steps:
 	//
 	// 1) Shutdown if we've been told to shutdown.
-	// 2) Dump caches if a cache-invalidation event occurred.
-	// 3) Sleep if we've been told to sleep in the previous iteration.
+	// 2) Sleep if we've been told to sleep in the previous iteration.
+	// 3) Dump caches if a cache-invalidation event occurred.
 	// 4) Attempt to find WAL files.
 	// 4a) Attempt to query the DB to find the WAL files.
 	// 4b) Attempt to query the process args to find the WAL files.
@@ -197,19 +197,23 @@ RETRY:
 			break RETRY
 		}
 
-		// 2) Dump cache. Calling Purge() on the WALCache purges all downstream
+		// 2) Sleep.  Sleep before purging the WALCache in order to allow processes
+		//    in flight to complete.  If the sleep is not called before the purge,
+		//    it's possible that an in-flight pg_xlogdump(1) would be cancelled
+		//    before it completed a run.  This means that during an unexpected
+		//    shutdown, FDs won't be closed for up to config.KeyPGPollInterval.
+		if !sleepBetweenIterations {
+			d := viper.GetDuration(config.KeyPGPollInterval)
+			time.Sleep(d)
+			sleepBetweenIterations = false
+		}
+
+		// 3) Dump cache. Calling Purge() on the WALCache purges all downstream
 		//    caches (i.e. ioCache and fhCache).
 		if purgeCache {
 			a.resetPGConnCtx()
 			a.walCache.Purge()
 			purgeCache = false
-		}
-
-		// 3) Sleep
-		if !sleepBetweenIterations {
-			d := viper.GetDuration(config.KeyPGPollInterval)
-			time.Sleep(d)
-			sleepBetweenIterations = false
 		}
 
 		// 4) Get WAL files

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -79,7 +79,6 @@ func New(cfg *config.Config) (a *Agent, err error) {
 	a.metrics.SetTextValue(metrics.VersionSelfVersion, buildtime.VERSION)
 
 	a.setupSignals()
-	a.resetPGConnCtx()
 
 	if err := a.initDBPool(cfg); err != nil {
 		return nil, errors.Wrap(err, "unable to initialize db connection pool")

--- a/agent/signals_linux.go
+++ b/agent/signals_linux.go
@@ -31,6 +31,7 @@ func (a *Agent) setupSignals() {
 	signal.Notify(a.signalCh, os.Interrupt, unix.SIGTERM, unix.SIGHUP, unix.SIGPIPE)
 
 	a.shutdownCtx, a.shutdown = context.WithCancel(context.Background())
+	a.pgConnCtx, a.pgConnShutdown = context.WithCancel(a.shutdownCtx)
 }
 
 // handleSignals runs the signal handler thread

--- a/agent/signals_unix.go
+++ b/agent/signals_unix.go
@@ -33,6 +33,7 @@ func (a *Agent) setupSignals() {
 	signal.Notify(a.signalCh, os.Interrupt, unix.SIGTERM, unix.SIGHUP, unix.SIGPIPE, unix.SIGINFO)
 
 	a.shutdownCtx, a.shutdown = context.WithCancel(context.Background())
+	a.pgConnCtx, a.pgConnShutdown = context.WithCancel(a.shutdownCtx)
 }
 
 // handleSignals runs the signal handler thread

--- a/agent/walcache/cache.go
+++ b/agent/walcache/cache.go
@@ -62,9 +62,10 @@ var xlogdumpRE = regexp.MustCompile(`s/d/r:([\d]+)/([\d]+)/([\d]+) (?:tid |blk/o
 // c) deliberately intollerant of scans because we know the input is monotonic
 // d) sized to include only the KeyWALReadahead
 type WALCache struct {
-	ctx context.Context
-	wg  sync.WaitGroup
-	cfg *config.WALCacheConfig
+	ctx       context.Context
+	pgConnCtx context.Context
+	wg        sync.WaitGroup
+	cfg       *config.WALCacheConfig
 
 	purgeLock sync.Mutex
 	c         gcache.Cache
@@ -83,13 +84,14 @@ var (
 	numConcurrentWALs    int64
 )
 
-func New(ctx context.Context, cfg *config.Config, circMetrics *cgm.CirconusMetrics, ioCache *iocache.IOCache) (*WALCache, error) {
+func New(pgConnCtx context.Context, ctx context.Context, cfg *config.Config, circMetrics *cgm.CirconusMetrics, ioCache *iocache.IOCache) (*WALCache, error) {
 	walWorkers := pg.NumOldLSNs * int(math.Ceil(float64(cfg.ReadaheadBytes)/float64(pg.WALSegmentSize)))
 
 	wc := &WALCache{
-		ctx:     ctx,
-		metrics: circMetrics,
-		cfg:     &cfg.WALCacheConfig,
+		pgConnCtx: pgConnCtx,
+		ctx:       ctx,
+		metrics:   circMetrics,
+		cfg:       &cfg.WALCacheConfig,
 
 		inFlightWALFiles: make(map[pg.WALFilename]struct{}, walWorkers),
 		ioCache:          ioCache,
@@ -253,6 +255,11 @@ func (wc *WALCache) ReadaheadBytes() units.Base2Bytes {
 	return wc.cfg.ReadaheadBytes
 }
 
+// ResetPGConnCtx resets a pgConnCtx
+func (wc *WALCache) ResetPGConnCtx(ctx context.Context) {
+	wc.pgConnCtx = ctx
+}
+
 // Wait blocks until the WALCache finishes shutting down its workers (including
 // the workers of its IOCache).
 func (wc *WALCache) Wait() {
@@ -275,7 +282,7 @@ func (wc *WALCache) prefaultWALFile(walFile pg.WALFilename) (err error) {
 		return errors.Wrap(err, "WAL file does not exist")
 	}
 
-	cmd := exec.CommandContext(wc.ctx, wc.cfg.XLogDumpPath, "-f", walFileAbs)
+	cmd := exec.CommandContext(wc.pgConnCtx, wc.cfg.XLogDumpPath, "-f", walFileAbs)
 	var errbuf bytes.Buffer
 	cmd.Stderr = &errbuf
 


### PR DESCRIPTION
When PostgreSQL is terminated, `pg_prefaulter`'s spawned instances of `pg_xlogdump` will still have an open file descriptor because `pg_xlogdump` is being invoked with the `-f` flag.  Introduce a new context that is used and tied to PostgreSQL connections.  Unfortunately this means we now sleep for a small duration before actually terminating `pg_xlogdump(1)` or closing FDs, however the default sleep duration is `1s`.

Fixes: #40 